### PR TITLE
Define default root query/mutation/subscription objects on schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,14 @@ Using PyQL:
 
 .. code-block:: python
 
-    from pyql import Object, Schema
+    from pyql import Schema
 
-    Query = Object('Query')
+    schema = Schema()
 
-    @Query.field('hello')
+    @schema.query.field('hello')
     def resolve_hello(root, info, name: str = 'world') -> str:
         return 'Hello {}'.format(name)
 
-    schema = Schema(query=Query)
     compiled = schema.compile()
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,6 +16,19 @@ Defining a basic schema
 
 .. code-block:: python
 
+    from pyql import Schema
+
+    schema = Schema()
+
+    @schema.query.field('hello')
+    def resolve_hello(root, info, argument: str = 'stranger') -> str:
+        return 'Hello ' + argument
+
+
+Or you can create your root Query object explicitly if you prefer doing so:
+
+.. code-block:: python
+
     from pyql import Object, Schema
 
     Query = Object('Query')

--- a/pyql/schema/compile.py
+++ b/pyql/schema/compile.py
@@ -52,6 +52,11 @@ def compile_schema(schema: Schema) -> GraphQLSchema:
 def _compile_object_or_none(obj):
     if obj is None:
         return None
+
+    if not obj.has_fields():
+        # Skip root objects with no fields, or graphql-core will complain
+        return None
+
     return compile_object(obj)
 
 

--- a/pyql/schema/types/core.py
+++ b/pyql/schema/types/core.py
@@ -9,9 +9,9 @@ class Schema:
     def __init__(self, *, query=None, mutation=None, subscription=None,
                  directives=None, types=None):
 
-        self.query = query
-        self.mutation = mutation
-        self.subscription = subscription
+        self.query = query or Object('Query')
+        self.mutation = mutation or Object('Mutation')
+        self.subscription = subscription or Object('Subscription')
         self.directives = directives
         self.types = types
 
@@ -89,6 +89,9 @@ class Object:
     def _define_field(self, name, field):
         self._assert_not_frozen()
         self.fields[name] = field
+
+    def has_fields(self):
+        return len(self.fields) > 0
 
     def __call__(self, **kwargs):
         return self.container_type(**kwargs)

--- a/tests/test_schema/test_schema.py
+++ b/tests/test_schema/test_schema.py
@@ -147,3 +147,21 @@ def test_schema_with_nested_objects_list():
         {'title': 'Two', 'body': 'Second post'},
     ]}
     assert result.errors is None
+
+
+def test_basic_schema_with_default_query_object():
+
+    schema = Schema()
+
+    @schema.query.field('hello')
+    def resolve_hello(root, info) -> str:
+        return 'Hello world'
+
+    compiled = schema.compile()
+
+    # ----------------------------------------------------------------
+
+    result = graphql(compiled, '{hello}')
+
+    assert result.data == {'hello': 'Hello world'}
+    assert result.errors is None


### PR DESCRIPTION
This reduces the amount of boilerplate code