### PR TITLE
Omit fields from result if they're missing on result object

### DIFF
--- a/pyql/__init__.py
+++ b/pyql/__init__.py
@@ -1,3 +1,7 @@
 # flake8: noqa
+
+# Monkey-patch graphql-core
+from . import patching
+
 from pyql.schema.types.core import (
     ID, InputObject, Interface, NonNull, Object, Schema, Union)

--- a/pyql/patching.py
+++ b/pyql/patching.py
@@ -1,0 +1,18 @@
+import graphql.execution.executor
+from graphql.execution.executor import complete_value as _complete_value_orig
+from graphql.utils.undefined import Undefined
+
+
+def _complete_value_patched(
+        exe_context, return_type, field_asts, info, path, result):
+
+    # We want to make sure Undefined values are passed through to
+    # executor, so that fields are correctly excluded from the result
+    if result is Undefined:
+        return Undefined
+
+    return _complete_value_orig(
+        exe_context, return_type, field_asts, info, path, result)
+
+
+graphql.execution.executor.complete_value = _complete_value_patched

--- a/pyql/schema/types/core.py
+++ b/pyql/schema/types/core.py
@@ -1,6 +1,7 @@
 import inspect
 
 import graphql
+from graphql.utils.undefined import Undefined
 
 from pyql.utils.cache import cached_property
 
@@ -108,7 +109,8 @@ class Object:
     @cached_property
     def container_type(self):
         self._freeze()
-        return make_container_type(self.name, {k: None for k in self.fields})
+        # return make_container_type(self.name, {k: None for k in self.fields})
+        return make_container_type(self.name, {})
 
     def __instancecheck__(self, instance):
         # Allow instances of the container type to look like
@@ -150,12 +152,12 @@ def make_default_resolver(name, default=None):
 
         if root is None:
             if default is None:
-                return None
+                return Undefined
             return default()
 
         # TODO: use subscript if mapping?
 
-        return getattr(root, name)
+        return getattr(root, name, Undefined)
 
     return default_resolver
 

--- a/tests/test_schema/test_schema.py
+++ b/tests/test_schema/test_schema.py
@@ -166,3 +166,29 @@ def test_basic_schema_with_default_query_object():
 
     assert result.data == {'hello': 'Hello world'}
     assert result.errors is None
+
+
+def test_return_partial_object():
+
+    import logging
+    logging.getLogger().debug('LOGGING IS ON')
+
+    schema = Schema()
+
+    MyObj = Object('MyObj', fields={
+        'foo': str,
+        'bar': str,
+    })
+
+    @schema.query.field('my_obj')
+    def resolve_my_obj(root, info) -> MyObj:
+        return MyObj(foo='FOO')
+
+    compiled = schema.compile()
+
+    # ----------------------------------------------------------------
+
+    result = graphql(compiled, '{ myObj { foo, bar } }')
+
+    assert result.errors is None
+    assert result.data == {'myObj': {'foo': 'FOO'}}


### PR DESCRIPTION
- Make default resolver return Undefined (instead of None) if an attribute is missing on the resulting object
- Monkey-patch graphql-core to honor Undefined values returned by resolver