### PR TITLE
Allow resolver to return any compatible type

### DIFF
--- a/pyql/schema/compile.py
+++ b/pyql/schema/compile.py
@@ -12,8 +12,8 @@ from graphql import (
     GraphQLSchema, GraphQLString, GraphQLUnionType)
 
 from pyql.schema.types.core import (
-    ID, Argument, Field, InputField, InputObject, Interface, List,
-    NonNull, Object, Schema, Union)
+    ID, Argument, Field, InputField, InputObject, Interface, List, NonNull,
+    Object, ObjectContainer, Schema, Union)
 from pyql.schema.types.enum_type import GraphQLEnumType
 from pyql.schema.types.extra import GraphQLDate, GraphQLDateTime, GraphQLTime
 from pyql.utils.str_converters import to_camel_case
@@ -97,12 +97,15 @@ class GraphQLCompiler:
 
         is_type_of = obj.is_type_of
         if is_type_of is None:
-            # Checks whether an object returned from a resolver belongs to
-            # this object type.
-            # We allow users to override this, but the default
-            # implementation should work fine in most cases, really..
+
             def is_type_of(val, info):
-                return isinstance(val, obj.container_object)
+                # If it's an instance of a container type, it must be
+                # the correct one.
+                if isinstance(val, ObjectContainer):
+                    return isinstance(val, obj.container_type)
+
+                # Accept any other object
+                return True
 
         compiled_type = GraphQLObjectType(
 

--- a/tests/test_compiled_schema_execution.py
+++ b/tests/test_compiled_schema_execution.py
@@ -1,0 +1,106 @@
+from collections import namedtuple
+
+from pyql import Object, Schema
+
+
+def test_resolver_can_return_container_instance():
+
+    schema = Schema()
+
+    Foo = Object('Foo', {'text': str})
+
+    @schema.query.field('foo')
+    def resolve_foo(root, info) -> Foo:
+        return Foo(text='a')
+
+    result = schema.execute("""
+    { foo { text } }
+    """)
+
+    assert result.errors is None
+    assert result.data == {'foo': {'text': 'a'}}
+
+
+def test_resolver_can_return_compatible_object():
+    """
+    Still a duck.
+    """
+
+    schema = Schema()
+
+    Foo = Object('Foo', {'text': str})
+    AnotherFoo = namedtuple('AnotherFoo', ('text',))
+
+    @schema.query.field('foo')
+    def resolve_foo(root, info) -> Foo:
+        return AnotherFoo(text='a')
+
+    result = schema.execute("""
+    { foo { text } }
+    """)
+
+    assert result.errors is None
+    assert result.data == {'foo': {'text': 'a'}}
+
+
+def test_resolver_cannot_return_different_container_instance():
+    """
+    An instance of a different "container" instance is considered a
+    mistake, even if the two are compatible.
+    """
+
+    schema = Schema()
+
+    Foo = Object('Foo', {'text': str})
+    Bar = Object('Bar', {'text': str})
+
+    @schema.query.field('foo')
+    def resolve_foo(root, info) -> Foo:
+        return Bar(text='a')
+
+    result = schema.execute("""
+    { foo { text } }
+    """)
+
+    assert result.data == {'foo': None}
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert result.errors[0].message == \
+        'Expected value of type "Foo" but got: Bar.'
+
+
+def test_returning_an_incompatible_object_fails():
+
+    schema = Schema()
+
+    Foo = Object('Foo', {'text': str})
+    Spam = namedtuple('Spam', ('spam',))
+
+    @schema.query.field('foo')
+    def resolve_foo(root, info) -> Foo:
+        return Spam(spam='SPAM' * 10)
+
+    result = schema.execute("""
+    { foo { text } }
+    """)
+
+    assert result.data == {'foo': {'text': None}}
+    assert result.errors is None
+
+
+def test_resolver_can_return_dict():
+
+    schema = Schema()
+
+    Foo = Object('Foo', {'text': str})
+
+    @schema.query.field('foo')
+    def resolve_foo(root, info) -> Foo:
+        return {'text': 'a'}
+
+    result = schema.execute("""
+    { foo { text } }
+    """)
+
+    assert result.errors is None
+    assert result.data == {'foo': {'text': 'a'}}


### PR DESCRIPTION
- No longer force return value to be of the correct container type
- ...unless it's an instance of a container type
- Also, handle dicts / Mappings from default resolver